### PR TITLE
Fix for causing errors when Field check box and radio has no key

### DIFF
--- a/src/Themosis/Page/Option.php
+++ b/src/Themosis/Page/Option.php
@@ -16,11 +16,12 @@ class Option
     {
         $option = get_option($optionGroup);
 
-        if (!empty($option))
+        if (!is_null($name))
         {
-            if (isset($option[$name]))
-            {
+            if (array_key_exists($name, $option)) {
                 return $option[$name];
+            } else {
+                return '';
             }
         }
 


### PR DESCRIPTION
Since check box and radio field stores a value of 0 if enabled and no key / value when not enable causes some problems when using the
Option::get function since key is not present.
